### PR TITLE
Hotfix uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # Online-thesaurus-vim
-This is a vim plugin that retrieves the synonyms and antonyms of a given word from the website at www.thesaurus.com. 
+This is a vim plugin that retrieves the synonyms and antonyms of a given word from the website at www.thesaurus.com.
 
-The credit for the original ideas go to Anton Beloglazov <http://beloglazov.info/> and Nick Coleman <http://www.nickcoleman.org/>. 
+The credit for the original ideas go to Anton Beloglazov <http://beloglazov.info/> and Nick Coleman <http://www.nickcoleman.org/>.
 ![](./screenshot.png)
 
 This plugin is implemented partially because the original plugin by Anton at
 https://github.com/beloglazov/vim-online-thesaurus
-seems to have stopped working as for 12/05/2018 on vim 8.0 on windows or Mac. The original implementation was through a bash script so a git bash installation is normally needed on windows. The current implementation eliminates this necessity by programming the core functionality in python. 
+seems to have stopped working as for 12/05/2018 on vim 8.0 on windows or Mac. The original implementation was through a bash script so a git bash installation is normally needed on windows. The current implementation eliminates this necessity by programming the core functionality in python.
 
 ## Pre-requisites
-1) Vim must have been compiled with python support (either python 2 or python 3 would work). 
+1) Vim must have been compiled with python support (either python 2 or python 3 would work).
 2) A python 2 or python 3 distribution is installed and it working properly with Vim. The plugin relies only on standard libraries so there is no need to install extra packages in your python distribution.
 
 To check you have both conditions satisfied, simply fire your vim and do
 
-```:py print(“hello”)``` 
+```:py print(“hello”)```
 or
 ```:py3 print(“hello”)```
 
 If you can see the output "hello" in the message area you are good to go. If not, see the FAQ at the bottom.
 
-## Installation 
+## Installation
 For vim version > 8.0 you can  install the plugin by
 ```
 cd ~/.vim/pack/plugins/start/
@@ -35,20 +35,20 @@ git clone https://github.com/Ben201310/online-thesaurus-vim
 ```
 
 ## Usage
-Usage is simple. 
+Usage is simple.
 
-1) Put your cursor on the word whose antonyms and synonyms you would like to know, then press 
+1) Put your cursor on the word whose antonyms and synonyms you would like to know, then press
 ```
 <Leader>t
  ```
  A preview windows will open at the bottom of the current window with retrieved content. You can close the window by pressing ```q```
 
-Alternatively, you could run the command 
+Alternatively, you could run the command
 ```
 :ThesaurusCurrent<CR>
 ```
 
-2) If you want to look for a specific word ‘quick’ for example. You can run 
+2) If you want to look for a specific word ‘quick’ for example. You can run
 ```
 :Thesaurus YOUOWNWORD<CR>
 ```
@@ -59,15 +59,15 @@ If you prefer a different key map for looking up the word under your cursor, put
 let g:use_default_key_map = 0
 nnoremap YOUR_OWN_KEY :call Thesaurus_LookCurrentWord()<CR>
 ```
-  
-## FAQ
-1. If your python support test does not go through, 
-    1. type
-    ```:version``` 
-    look for something like ```+python``` or ```+python3``` in the output. If you could not find them, you may need to reinstall your vim using a version with python support. 
 
-    2. If you found the ```+python``` or ```+python3``` entries, you vim instalation should be fine. The problem could either be due to 
-        1. your do not have a python distribution installed, or it is not stored in the $PATH enviroment variable. 
+## FAQ
+1. If your python support test does not go through,
+    1. type
+    ```:version```
+    look for something like ```+python``` or ```+python3``` in the output. If you could not find them, you may need to reinstall your vim using a version with python support.
+
+    2. If you found the ```+python``` or ```+python3``` entries, you vim instalation should be fine. The problem could either be due to
+        1. your do not have a python distribution installed, or it is not stored in the $PATH enviroment variable.
         2. You have installed a 64-bit python distribution while your vim is a 32-bit installation, or vice versa. In this case, reinstalling python to match vim's architeture should work.
 
 

--- a/autoload/thesaurusPy2Vim.vim
+++ b/autoload/thesaurusPy2Vim.vim
@@ -1,23 +1,23 @@
 " File: thesaurusPy2Vim.vim
 " Author: Benshuai Lyu
 " License: GPLv3
-" Description: 
+" Description:
 " 	" This is a vim script wrapper for the python plugin, which
 "	" retrieves the thesaurus of the given requested word from
 " 	" the website at www.thesaurus.com. Original idea comes from
-	"  Anton Beloglazov <http://beloglazov.info/> 
+	"  Anton Beloglazov <http://beloglazov.info/>
 	"  and
 	"  Nick Coleman <http://www.nickcoleman.org/>
 
 
-if exists("g:THESAURUSPY2VIM")
+if exists("g:thesauruspy2vim")
     finish
 endif
-let g:THESAURUSPY2VIM= 1
+let g:thesauruspy2vim= 1
 
 
 
-"take the import outside so that you don't need to import 
+"take the import outside so that you don't need to import
 "evertime you call the function
 
 python import vim
@@ -30,7 +30,7 @@ let s:modulePath = s:currentScriptPath . '/../modules/'
 python sys.path.append(vim.eval('s:modulePath'))
 python from extract_thesaurus import *
 
-" note you cannot use python 'from extract_thesaurus import *' 
+" note you cannot use python 'from extract_thesaurus import *'
 " because these "quotes will be carried over and the python
 " statement is a string obj.
 

--- a/modules/extract_thesaurus.py
+++ b/modules/extract_thesaurus.py
@@ -1,12 +1,12 @@
 '''This program defines a function online_thesaurus()
-to find the synonyms and antonyms of a given word. 
+to find the synonyms and antonyms of a given word.
 The function syntax is
 
 online_thesaurus(word)
 
 where word is a string specifying the request word and
-the return value is a list of definition families. 
-A definition family is a class representing the definition, 
+the return value is a list of definition families.
+A definition family is a class representing the definition,
 synonyms and antonyms etc of a particluar meaning
 
 '''

--- a/modules/html_extract_tools.py
+++ b/modules/html_extract_tools.py
@@ -13,8 +13,8 @@ elif sys.version_info[0] <= 2:
 
 
 def save_retrieved_html(word):
-    '''This function retrieves the html page for the word "word", 
-    then save the file to a temporary file. The file name will 
+    '''This function retrieves the html page for the word "word",
+    then save the file to a temporary file. The file name will
     be returned at the end.
     '''
 
@@ -26,14 +26,14 @@ def save_retrieved_html(word):
 
 def extract_definition_line(tem_file_name):
     '''This function opens the webpage file stored previously using the
-    function save_retrieved_html(). Then it looks for the line containing 
+    function save_retrieved_html(). Then it looks for the line containing
     all the definitions, synonyms and antonyms. These explanation is stored
     soley within one super long line. This function returns this long line using
     a string object
     '''
-    # the following is because the builtin open function in python2 
+    # the following is because the builtin open function in python2
     # does not support encoding parameter. use io.open instead. But
-    # io.open().readline() returns the UNICODE STRING reprsentation of 
+    # io.open().readline() returns the UNICODE STRING reprsentation of
     # each character. Therefore you need to encode it using utf-8
     if sys.version_info[0] <= 2:
         with io.open(tem_file_name, 'r', encoding='utf-8') as f:
@@ -66,17 +66,17 @@ def extract_definition_line(tem_file_name):
 
 def split_definition_groups(definition_line):
     ''''This function splits the super long definition line into a list of
-    strings, each of which is a definition group. It contains its explanation, 
+    strings, each of which is a definition group. It contains its explanation,
     synatic function, synonyms and antonyms. Each group has the following format
 
     {"isInformal": null, ... definition: "very great",...
-    "pos", ajd", "synonyms": [{"similarity":"100", ..."targetTerm": "acute"...}{}{}...], 
+    "pos", ajd", "synonyms": [{"similarity":"100", ..."targetTerm": "acute"...}{}{}...],
     "antonyms": [{"similarity":"-100", ...TargetTerm: "calm",...},{},{}....]a
     }
 
     Note the above group is a one-line string when returned as list member
 
-    The call signature is 
+    The call signature is
 
     split_definition_groups(definition_line)
 
@@ -88,25 +88,25 @@ def split_definition_groups(definition_line):
 
 def extract_pair_values_via_key(str, key, value_quote_type):
     '''This function extracts the value from the string input of the form
-    r{"key1": "value1", "key2":"value2"...} (note this is the literal 
+    r{"key1": "value1", "key2":"value2"...} (note this is the literal
     content, not a python dictionary) via specifying the key and
-    the quote type of the corresponding value. The output strips the quotes 
-    of the value. But the key must be indential to the that appeared in the 
+    the quote type of the corresponding value. The output strips the quotes
+    of the value. But the key must be indential to the that appeared in the
     original input string.
-    Its call signature is 
+    Its call signature is
 
-    extract_pair_values_by_key(str, key, value_quote_type) 
+    extract_pair_values_by_key(str, key, value_quote_type)
     # str: input str such as {"key1": "value1", "key2":"value2"...},
-    # key: key string such as '"key1"'. 
+    # key: key string such as '"key1"'.
     # value_quote_type: such has '"' or r'['
 
-    # Note here you need to # put quotes around key1 because 
-    # it is inside the string. However, for convenience, 
+    # Note here you need to # put quotes around key1 because
+    # it is inside the string. However, for convenience,
     # the output values will have their quotes stripped away.
 
 
-    Note if multiple pairs having the same key, it returns a list of values, 
-    each member of which is a string. Otherwise it still return a list but 
+    Note if multiple pairs having the same key, it returns a list of values,
+    each member of which is a string. Otherwise it still return a list but
     the length of which is one.
     '''
 
@@ -125,16 +125,16 @@ def extract_pair_values_via_key(str, key, value_quote_type):
 
 
 def parse_group(explanation_group, type=None):
-    '''This function parses a single splitted explanation group. It deprives 
+    '''This function parses a single splitted explanation group. It deprives
     all other useless information and only retrain the request results
 
     Its call signature is:
 
-    parse_group(group)  # return a string for its definition 
+    parse_group(group)  # return a string for its definition
     parse_group(group, [type=]'definition') # return a str for its def
     parse_group(group, [type=]'syntax') # return a str for its syntax
     parse_group(group, [type=]'synonym') # return a list of its synonyms
-    parse_group(group, [type=]'antonym') # return a list of its antonyms 
+    parse_group(group, [type=]'antonym') # return a list of its antonyms
 
     '''
     if (type == None or type == 'definition'):

--- a/plugin/thesaurus.vim
+++ b/plugin/thesaurus.vim
@@ -1,26 +1,26 @@
 " File: thesaurus.vim
 " Author: Benshuai Lyu
 " License: GPLv3
-" Description: 
+" Description:
 " 	" This is a vim script wrapper for the python plugin which
 "	" retrieves the thesaurus of the given requested word from
 " 	" the website at www.thesaurus.com. Original idea comes from
-	"  Anton Beloglazov <http://beloglazov.info/> 
+	"  Anton Beloglazov <http://beloglazov.info/>
 	"  and
 	"  Nick Coleman <http://www.nickcoleman.org/>
 	" This specific wraper file (2nd half) exposes a handful of
 " 	" necessary commands and keymaps to users. Another wrapper
-" 	" file (1st half) bridges the graps between python and  
+" 	" file (1st half) bridges the graps between python and
 " 	" vim script is under autload for efficiency considerations.
 
 
-if exists("g:ONLINE_THESAURUS")
+if exists("g:online_thesaurus")
     finish
 endif
-let g:ONLINE_THESAURUS = 1
+let g:online_thesaurus = 1
 
 
-"create default mapping 
+"create default mapping
 "
 if !exists("g:use_default_key_map")
 

--- a/syntax/thesaurus.vim
+++ b/syntax/thesaurus.vim
@@ -1,11 +1,11 @@
 " File: thesaurus.vim
 " Author: Benshuai Lyu
 " License: GPLv3
-" Description: 
+" Description:
 " 	" This is a vim script wrapper for the python plugin, which
 "	" retrieves the thesaurus of the given requested word from
 " 	" the website at www.thesaurus.com. Original idea comes from
-	"  Anton Beloglazov <http://beloglazov.info/> 
+	"  Anton Beloglazov <http://beloglazov.info/>
 	"  and
 	"  Nick Coleman <http://www.nickcoleman.org/>
 
@@ -17,9 +17,9 @@ let b:current_syntax = "thesaurus"
 syntax case match
 
 syntax keyword definition DEFINITION:
-syntax keyword syntax PART OF SPEECH: 
-syntax keyword synonym SYNONYMS: 
-syntax keyword antonym ANTONYMS: 
+syntax keyword syntax PART OF SPEECH:
+syntax keyword synonym SYNONYMS:
+syntax keyword antonym ANTONYMS:
 
 hi link definition keyword
 hi link syntax keyword


### PR DESCRIPTION
The main change of this pull request changes UPPERCASE vim variables to lowercase vim variable.

In neovim, the editor makes UPPERCASE variables to global and saves it to info file.
So, PlugIn pass ThesaurusPy2Vim.vim and thesaurus.vim(because of the existing variables)
To solve this problem, this replaces UPPERCASE variables with lowercase variables.

Second, trim all trailing spaces.